### PR TITLE
BACK | Recebe atividades com limite de dados

### DIFF
--- a/src/back-end/src/controllers/activityHistory.controller.ts
+++ b/src/back-end/src/controllers/activityHistory.controller.ts
@@ -69,6 +69,31 @@ export const getUserActivities = async (
 	}
 };
 
+// Busca todas as atividades de um usuário
+export const getUserRangeActivities = async (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	try {
+		const { userId, range } = req.params;
+
+		if (!userId) {
+			res.status(400).json({ message: 'User ID is required' });
+			return;
+		}
+
+		const activities =
+			await ActivityService.getUserRangeActivities(
+				userId,
+				Number(range),
+			);
+		res.status(200).json(activities);
+	} catch (error) {
+		next(error);
+	}
+};
+
 // Busca uma atividade pelo ID
 export const getActivityById = async (
 	req: Request,

--- a/src/back-end/src/routes/activityHistory.routes.ts
+++ b/src/back-end/src/routes/activityHistory.routes.ts
@@ -3,6 +3,7 @@ import {
 	createActivity,
 	getUserActivities,
 	getActivityById,
+	getUserRangeActivities,
 } from '../controllers/activityHistory.controller';
 import { authenticate } from '../middlewares/auth.middleware';
 
@@ -20,6 +21,13 @@ router.get(
 	'/:userId/activities',
 	authenticate,
 	getUserActivities,
+);
+
+// Obter limitadas atividades de um usuário
+router.get(
+	'/:userId/activities/filter/:range',
+	authenticate,
+	getUserRangeActivities,
 );
 
 // Obter atividade pelo id da atividade

--- a/src/back-end/src/services/activityHistory.service.ts
+++ b/src/back-end/src/services/activityHistory.service.ts
@@ -34,6 +34,18 @@ export const getUserActivities = async (
 	});
 };
 
+// Busca todas as atividades de um usuário
+export const getUserRangeActivities = async (
+	userId: string,
+	range: number,
+): Promise<UserActivityHistoryDocument[]> => {
+	return await ActivityHistoryModel.find({
+		userReference: userId,
+	})
+		.sort({ timestampStart: -1 })
+		.limit(range);
+};
+
 // Busca uma atividade específica por ID (com dados do usuário populados)
 export const getActivityById = async (
 	activityId: string,


### PR DESCRIPTION
Adiciona rota, controlador e "serviço" para nova função de receber dados das atividades de um usuário definindo limite de quantas atividades deve-se buscar.